### PR TITLE
IAM roles for EC2 instances

### DIFF
--- a/src/queen/HiveInstance.java
+++ b/src/queen/HiveInstance.java
@@ -4,8 +4,10 @@ import static ox.util.Utils.normalize;
 
 import java.time.Duration;
 
+import com.amazonaws.services.ec2.model.AssociateIamInstanceProfileRequest;
 import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DeleteTagsRequest;
+import com.amazonaws.services.ec2.model.IamInstanceProfileSpecification;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.InstanceType;
@@ -159,6 +161,14 @@ public class HiveInstance {
               .withTags(tag));
       instance.withTags(tag);
     }
+    return this;
+  }
+
+  public HiveInstance withIAMRole(String instanceId, String instanceProfileArn) {
+    queen.getEC2().associateIamInstanceProfile(
+        new AssociateIamInstanceProfileRequest()
+            .withInstanceId(instanceId)
+            .withIamInstanceProfile(new IamInstanceProfileSpecification().withArn(instanceProfileArn)));
     return this;
   }
 


### PR DESCRIPTION
The most immediate use case is to attach a role to enable SSM that lets us use AWS solution for remote SSH. 

Through SSM , we no longer need to provision SSH keys and remote shell access can be turned off by disabling the user's account on G-Suite. 